### PR TITLE
Enhance block reader

### DIFF
--- a/sstable/block_reader.cc
+++ b/sstable/block_reader.cc
@@ -9,21 +9,19 @@ namespace kvs {
 
 namespace sstable {
 
-bool 
 
-BlockReader::BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object,
-                         size_t size)
-    : read_file_object_(read_file_object) {
-  assert(size > 0);
-  buffer_.resize(size);
-}
+// BlockReader::BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object,
+//                          size_t size) {
+//   assert(size > 0);
+//   buffer_.resize(size);
+// }
 
 BlockReader::BlockReader(std::unique_ptr<BlockReaderData> block_reader_data)
     : total_data_entries_(block_reader_data->total_data_entries),
       offset_section_(block_reader_data->offset_section),
       data_entries_offset_info_(
           std::move(block_reader_data->data_entries_offset_info)),
-      buffer_(std:move(block_reader_data->buffer)) {}
+      buffer_(std::move(block_reader_data->buffer)) {}
 
 // bool BlockReader::FetchBlockData(BlockOffset offset) {
 //   if (offset < 0) {

--- a/sstable/block_reader.cc
+++ b/sstable/block_reader.cc
@@ -9,6 +9,8 @@ namespace kvs {
 
 namespace sstable {
 
+bool 
+
 BlockReader::BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object,
                          size_t size)
     : read_file_object_(read_file_object) {
@@ -16,30 +18,37 @@ BlockReader::BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object,
   buffer_.resize(size);
 }
 
-bool BlockReader::FetchBlockData(BlockOffset offset) {
-  if (offset < 0) {
-    return false;
-  }
+BlockReader::BlockReader(std::unique_ptr<BlockReaderData> block_reader_data)
+    : total_data_entries_(block_reader_data->total_data_entries),
+      offset_section_(block_reader_data->offset_section),
+      data_entries_offset_info_(
+          std::move(block_reader_data->data_entries_offset_info)),
+      buffer_(std:move(block_reader_data->buffer)) {}
 
-  ssize_t bytes_read = read_file_object_->RandomRead(buffer_, offset);
-  if (bytes_read < 0) {
-    return false;
-  }
+// bool BlockReader::FetchBlockData(BlockOffset offset) {
+//   if (offset < 0) {
+//     return false;
+//   }
 
-  int64_t last_block_offset = buffer_.size() - 1;
-  // 16 last bytes of lock contain metadata info(num entries + starting offset
-  // of offset section)
-  total_data_entries_ =
-      *reinterpret_cast<uint64_t *>(&buffer_[last_block_offset - 15]);
-  offset_section_ =
-      *reinterpret_cast<uint64_t *>(&buffer_[last_block_offset - 7]);
+//   ssize_t bytes_read = read_file_object_->RandomRead(buffer_, offset);
+//   if (bytes_read < 0) {
+//     return false;
+//   }
 
-  for (uint64_t i = 0; i < total_data_entries_; i++) {
-    data_entries_offset_info_.emplace_back(GetDataEntryOffset(i));
-  }
+//   int64_t last_block_offset = buffer_.size() - 1;
+//   // 16 last bytes of lock contain metadata info(num entries + starting offset
+//   // of offset section)
+//   total_data_entries_ =
+//       *reinterpret_cast<uint64_t *>(&buffer_[last_block_offset - 15]);
+//   offset_section_ =
+//       *reinterpret_cast<uint64_t *>(&buffer_[last_block_offset - 7]);
 
-  return true;
-}
+//   for (uint64_t i = 0; i < total_data_entries_; i++) {
+//     data_entries_offset_info_.emplace_back(GetDataEntryOffset(i));
+//   }
+
+//   return true;
+// }
 
 db::GetStatus BlockReader::SearchKey(std::string_view key, TxnId txn_id) const {
   db::GetStatus status;

--- a/sstable/block_reader.cc
+++ b/sstable/block_reader.cc
@@ -9,44 +9,12 @@ namespace kvs {
 
 namespace sstable {
 
-
-// BlockReader::BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object,
-//                          size_t size) {
-//   assert(size > 0);
-//   buffer_.resize(size);
-// }
-
 BlockReader::BlockReader(std::unique_ptr<BlockReaderData> block_reader_data)
     : total_data_entries_(block_reader_data->total_data_entries),
       offset_section_(block_reader_data->offset_section),
       data_entries_offset_info_(
           std::move(block_reader_data->data_entries_offset_info)),
       buffer_(std::move(block_reader_data->buffer)) {}
-
-// bool BlockReader::FetchBlockData(BlockOffset offset) {
-//   if (offset < 0) {
-//     return false;
-//   }
-
-//   ssize_t bytes_read = read_file_object_->RandomRead(buffer_, offset);
-//   if (bytes_read < 0) {
-//     return false;
-//   }
-
-//   int64_t last_block_offset = buffer_.size() - 1;
-//   // 16 last bytes of lock contain metadata info(num entries + starting offset
-//   // of offset section)
-//   total_data_entries_ =
-//       *reinterpret_cast<uint64_t *>(&buffer_[last_block_offset - 15]);
-//   offset_section_ =
-//       *reinterpret_cast<uint64_t *>(&buffer_[last_block_offset - 7]);
-
-//   for (uint64_t i = 0; i < total_data_entries_; i++) {
-//     data_entries_offset_info_.emplace_back(GetDataEntryOffset(i));
-//   }
-
-//   return true;
-// }
 
 db::GetStatus BlockReader::SearchKey(std::string_view key, TxnId txn_id) const {
   db::GetStatus status;

--- a/sstable/block_reader.h
+++ b/sstable/block_reader.h
@@ -39,6 +39,7 @@ struct BlockReaderData {
   // Contain starting offset and length of each data entries
   std::vector<uint64_t> data_entries_offset_info;
 
+  // Buffer that data from block is written into
   std::vector<Byte> buffer;
 };
 
@@ -132,8 +133,6 @@ private:
 
   // Contain starting offset and length of each data entries
   const std::vector<uint64_t> data_entries_offset_info_;
-
-  // const std::shared_ptr<io::ReadOnlyFile> read_file_object_;
 };
 
 } // namespace sstable

--- a/sstable/block_reader.h
+++ b/sstable/block_reader.h
@@ -26,9 +26,9 @@ struct BlockReaderData {
   }
 
   // Move constructor/assignment
-  BlockReaderData(BlockReaderData&&) = default;
+  BlockReaderData(BlockReaderData &&) = default;
 
-  BlockReaderData& operator=(BlockReaderData&&) = default;
+  BlockReaderData &operator=(BlockReaderData &&) = default;
 
   // Total data entries in a block
   uint64_t total_data_entries;
@@ -89,7 +89,6 @@ Extra format
 
 class BlockReader {
 public:
-  // BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object, size_t size);
   BlockReader(std::unique_ptr<BlockReaderData> block_reader_data);
   ~BlockReader() = default;
 

--- a/sstable/block_reader.h
+++ b/sstable/block_reader.h
@@ -19,6 +19,13 @@ class ReadOnlyFile;
 namespace sstable {
 
 struct BlockReaderData {
+  BlockReaderData() = default;
+
+  // Move constructor/assignment
+  BlockReaderData(BlockReaderData&&) = default;
+
+  BlockReaderData& operator=(BlockReaderData&&) = default;
+
   // Total data entries in a block
   uint64_t total_data_entries;
 
@@ -29,11 +36,6 @@ struct BlockReaderData {
   std::vector<uint64_t> data_entries_offset_info;
 
   std::vector<Byte> buffer;
-
-  // Move constructor/assignment
-  BlockReaderData(BlockReaderData&&) = default;
-
-  BlockReaderData* operator=(BlockReaderData&&) = default;
 };
 
 /*
@@ -82,7 +84,7 @@ Extra format
 
 class BlockReader {
 public:
-  BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object, size_t size);
+  // BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object, size_t size);
   BlockReader(std::unique_ptr<BlockReaderData> block_reader_data);
   ~BlockReader() = default;
 

--- a/sstable/block_reader.h
+++ b/sstable/block_reader.h
@@ -101,8 +101,6 @@ public:
   BlockReader(BlockReader &&) = default;
   BlockReader &operator=(BlockReader &&) = default;
 
-  bool FetchBlockData(BlockOffset offset);
-
   db::GetStatus SearchKey(std::string_view key, TxnId txn_id) const;
 
   friend class BlockReaderIterator;

--- a/sstable/block_reader.h
+++ b/sstable/block_reader.h
@@ -5,6 +5,7 @@
 #include "db/status.h"
 
 // libC++
+#include <cassert>
 #include <memory>
 #include <span>
 #include <string_view>
@@ -19,7 +20,10 @@ class ReadOnlyFile;
 namespace sstable {
 
 struct BlockReaderData {
-  BlockReaderData() = default;
+  BlockReaderData(uint64_t block_size) {
+    assert(block_size > 0);
+    buffer.resize(block_size);
+  }
 
   // Move constructor/assignment
   BlockReaderData(BlockReaderData&&) = default;

--- a/sstable/block_reader.h
+++ b/sstable/block_reader.h
@@ -18,6 +18,24 @@ class ReadOnlyFile;
 
 namespace sstable {
 
+struct BlockReaderData {
+  // Total data entries in a block
+  uint64_t total_data_entries;
+
+  // Starting offset of offset section
+  uint64_t offset_section;
+
+  // Contain starting offset and length of each data entries
+  std::vector<uint64_t> data_entries_offset_info;
+
+  std::vector<Byte> buffer;
+
+  // Move constructor/assignment
+  BlockReaderData(BlockReaderData&&) = default;
+
+  BlockReaderData* operator=(BlockReaderData&&) = default;
+};
+
 /*
 Block data format(unit: Byte)
 --------------------------------------------------------------------------------
@@ -65,6 +83,7 @@ Extra format
 class BlockReader {
 public:
   BlockReader(std::shared_ptr<io::ReadOnlyFile> read_file_object, size_t size);
+  BlockReader(std::unique_ptr<BlockReaderData> block_reader_data);
   ~BlockReader() = default;
 
   // No copy allowed
@@ -97,18 +116,18 @@ private:
   // Get value of data entry that start at data_entry_offset
   std::string_view GetValueFromDataEntry(uint64_t data_entry_offset) const;
 
-  mutable std::vector<Byte> buffer_;
+  const std::vector<Byte> buffer_;
 
   // Total data entries in a block
-  uint64_t total_data_entries_;
+  const uint64_t total_data_entries_;
 
   // Starting offset of offset section
-  uint64_t offset_section_;
+  const uint64_t offset_section_;
 
   // Contain starting offset and length of each data entries
-  std::vector<uint64_t> data_entries_offset_info_;
+  const std::vector<uint64_t> data_entries_offset_info_;
 
-  const std::shared_ptr<io::ReadOnlyFile> read_file_object_;
+  // const std::shared_ptr<io::ReadOnlyFile> read_file_object_;
 };
 
 } // namespace sstable

--- a/sstable/block_reader_cache.cc
+++ b/sstable/block_reader_cache.cc
@@ -35,7 +35,7 @@ BlockReaderCache::GetKeyFromBlockCache(std::string_view key, TxnId txn_id,
     std::shared_lock rlock(mutex_);
     const BlockReader *block_reader = GetBlockReader(block_info);
     if (block_reader) {
-      // if table reader had already been in cache
+      // if tablereader had already been in cache
       status = block_reader->SearchKey(key, txn_id);
       return status;
     }
@@ -45,28 +45,22 @@ BlockReaderCache::GetKeyFromBlockCache(std::string_view key, TxnId txn_id,
       table_reader_cache_->GetTableReader(block_info.first);
   assert(table_reader);
 
-  // Setup data for new block reader by table reader
+  // Setup data for new blockreader by tablereader
   std::unique_ptr<BlockReaderData> block_reader_data = 
       table_reader->SetupDataForBlockReader(block_size, block_info.second);
 
-  // Create new table reader
-  // auto new_block_reader = std::make_unique<BlockReader>(
-  //     table_reader->GetReadFileObject(), block_size);
+  // Create new tablereader
   auto new_block_reader = std::make_unique<BlockReader>(
       std::move(block_reader_data));
-  // // Immediately fetch data from block into memory
-  // if (!new_block_reader->FetchBlockData(block_info.second)) {
-  //   return status;
-  // }
 
   {
-    // Insert new block reader into cache
+    // Insert new blockreader into cache
     std::scoped_lock rwlock(mutex_);
     block_reader_cache_.insert(
         std::make_pair(block_info, std::move(new_block_reader)));
   }
 
-  // Search key in new block reader
+  // Lookup key in new blockreader
   std::shared_lock rlock(mutex_);
   const BlockReader *block_reader = GetBlockReader(block_info);
   assert(block_reader);

--- a/sstable/block_reader_cache.cc
+++ b/sstable/block_reader_cache.cc
@@ -47,7 +47,7 @@ BlockReaderCache::GetKeyFromBlockCache(std::string_view key, TxnId txn_id,
 
   // Setup data for new block reader by table reader
   std::unique_ptr<BlockReaderData> block_reader_data = 
-      table_reader->SetupDataForBlockReader(block_info.second);
+      table_reader->SetupDataForBlockReader(block_size, block_info.second);
 
   // Create new table reader
   // auto new_block_reader = std::make_unique<BlockReader>(

--- a/sstable/block_reader_cache.cc
+++ b/sstable/block_reader_cache.cc
@@ -45,13 +45,19 @@ BlockReaderCache::GetKeyFromBlockCache(std::string_view key, TxnId txn_id,
       table_reader_cache_->GetTableReader(block_info.first);
   assert(table_reader);
 
+  // Setup data for new block reader by table reader
+  std::unique_ptr<BlockReaderData> block_reader_data = 
+      table_reader->SetupDataForBlockReader(block_info.second);
+
   // Create new table reader
+  // auto new_block_reader = std::make_unique<BlockReader>(
+  //     table_reader->GetReadFileObject(), block_size);
   auto new_block_reader = std::make_unique<BlockReader>(
-      table_reader->GetReadFileObject(), block_size);
-  // Immediately fetch data from block into memory
-  if (!new_block_reader->FetchBlockData(block_info.second)) {
-    return status;
-  }
+      std::move(block_reader_data));
+  // // Immediately fetch data from block into memory
+  // if (!new_block_reader->FetchBlockData(block_info.second)) {
+  //   return status;
+  // }
 
   {
     // Insert new block reader into cache

--- a/sstable/table_reader.cc
+++ b/sstable/table_reader.cc
@@ -8,7 +8,7 @@
 namespace {
 
 uint64_t GetDataEntryOffset(uint64_t offset_section, int entry_index,
-                            std::span<const kvs::Byte> buffer)  {
+                            std::span<const kvs::Byte> buffer) {
   // Starting offset of offset entry at index (entry_index) (th)
   uint64_t offset_entry = offset_section + entry_index * 2 * sizeof(uint64_t);
 
@@ -18,7 +18,7 @@ uint64_t GetDataEntryOffset(uint64_t offset_section, int entry_index,
   return data_entry_offset;
 }
 
-} // namespace 
+} // namespace
 
 namespace kvs {
 constexpr int kDefaultExtraInfoSize = 40; // Bytes
@@ -174,7 +174,8 @@ db::GetStatus TableReader::SearchKey(
 }
 
 std::unique_ptr<BlockReaderData>
-    TableReader::SetupDataForBlockReader(uint64_t block_size, BlockOffset offset) const {
+TableReader::SetupDataForBlockReader(uint64_t block_size,
+                                     BlockOffset offset) const {
   if (offset < 0) {
     return nullptr;
   }
@@ -189,23 +190,17 @@ std::unique_ptr<BlockReaderData>
   int64_t last_block_offset = block_reader_data->buffer.size() - 1;
   // 16 last bytes of lock contain metadata info(num entries + starting offset
   // of offset section)
-  block_reader_data->total_data_entries =
-      *reinterpret_cast<uint64_t *>(&block_reader_data->buffer[last_block_offset - 15]);
-  block_reader_data->offset_section =
-      *reinterpret_cast<uint64_t *>(&block_reader_data->buffer[last_block_offset - 7]);
+  block_reader_data->total_data_entries = *reinterpret_cast<uint64_t *>(
+      &block_reader_data->buffer[last_block_offset - 15]);
+  block_reader_data->offset_section = *reinterpret_cast<uint64_t *>(
+      &block_reader_data->buffer[last_block_offset - 7]);
 
   for (uint64_t i = 0; i < block_reader_data->total_data_entries; i++) {
-    block_reader_data->data_entries_offset_info
-        .emplace_back(GetDataEntryOffset(block_reader_data->offset_section, i,
-                                         block_reader_data->buffer));
+    block_reader_data->data_entries_offset_info.emplace_back(GetDataEntryOffset(
+        block_reader_data->offset_section, i, block_reader_data->buffer));
   }
 
   return block_reader_data;
-}
-
-
-const std::shared_ptr<io::ReadOnlyFile> TableReader::GetReadFileObject() const {
-  return read_file_object_;
 }
 
 uint64_t TableReader::GetFileSize() const { return file_size_; }

--- a/sstable/table_reader.cc
+++ b/sstable/table_reader.cc
@@ -174,12 +174,12 @@ db::GetStatus TableReader::SearchKey(
 }
 
 std::unique_ptr<BlockReaderData>
-    TableReader::SetupDataForBlockReader(BlockOffset offset) const {  
+    TableReader::SetupDataForBlockReader(uint64_t block_size, BlockOffset offset) const {
   if (offset < 0) {
     return nullptr;
   }
 
-  auto block_reader_data = std::make_unique<BlockReaderData>();
+  auto block_reader_data = std::make_unique<BlockReaderData>(block_size);
   ssize_t bytes_read =
       read_file_object_->RandomRead(block_reader_data->buffer, offset);
   if (bytes_read < 0) {
@@ -196,8 +196,7 @@ std::unique_ptr<BlockReaderData>
 
   for (uint64_t i = 0; i < block_reader_data->total_data_entries; i++) {
     block_reader_data->data_entries_offset_info
-        .emplace_back(GetDataEntryOffset(i, 
-                                         block_reader_data->offset_section,
+        .emplace_back(GetDataEntryOffset(block_reader_data->offset_section, i,
                                          block_reader_data->buffer));
   }
 

--- a/sstable/table_reader.cc
+++ b/sstable/table_reader.cc
@@ -158,6 +158,37 @@ db::GetStatus TableReader::SearchKey(
       key, txn_id, {table_id_, block_offset}, block_size);
 }
 
+std::unique_ptr<BlockReaderData>
+    TableReader::SetupDataForBlockReader(BlockOffset offset) const {  
+  if (offset < 0) {
+    return nullptr;
+  }
+
+  std::vector<Byte> buffer;
+  ssize_t bytes_read = read_file_object_->RandomRead(buffer, offset);
+  if (bytes_read < 0) {
+    return nullptr;
+  }
+
+  auto block_reader_data = std::make_unique<BlockReaderData>();
+  int64_t last_block_offset = buffer.size() - 1;
+  // 16 last bytes of lock contain metadata info(num entries + starting offset
+  // of offset section)
+  block_reader_data->total_data_entries_ =
+      *reinterpret_cast<uint64_t *>(&buffer[last_block_offset - 15]);
+  block_reader_data->offset_section_ =
+      *reinterpret_cast<uint64_t *>(&buffer[last_block_offset - 7]);
+
+  for (uint64_t i = 0; i < total_data_entries_; i++) {
+    block_reader_data->data_entries_offset_info
+        .emplace_back(GetDataEntryOffset(i));
+  }
+  block_reader_data->buffer = std::move(buffer);
+
+  return block_reader_data;
+}
+
+
 const std::shared_ptr<io::ReadOnlyFile> TableReader::GetReadFileObject() const {
   return read_file_object_;
 }

--- a/sstable/table_reader.h
+++ b/sstable/table_reader.h
@@ -8,6 +8,7 @@
 // libC++
 #include <cassert>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -20,6 +21,7 @@ class ReadOnlyFile;
 namespace sstable {
 class BlockIndex;
 class BlockReaderCache;
+class BlockReaderData;
 
 /*
 SST data format
@@ -69,7 +71,8 @@ public:
       std::string_view key, TxnId txn_id,
       const sstable::BlockReaderCache *block_reader_cache) const;
 
-  std::unique_ptr<BlockReaderData> SetupDataForBlockReader(BlockOffset offset) const;
+  std::unique_ptr<BlockReaderData>
+      SetupDataForBlockReader(BlockOffset offset) const;
 
   const std::shared_ptr<io::ReadOnlyFile> GetReadFileObject() const;
 

--- a/sstable/table_reader.h
+++ b/sstable/table_reader.h
@@ -69,6 +69,8 @@ public:
       std::string_view key, TxnId txn_id,
       const sstable::BlockReaderCache *block_reader_cache) const;
 
+  std::unique_ptr<BlockReaderData> SetupDataForBlockReader(BlockOffset offset) const;
+
   const std::shared_ptr<io::ReadOnlyFile> GetReadFileObject() const;
 
   uint64_t GetFileSize() const;

--- a/sstable/table_reader.h
+++ b/sstable/table_reader.h
@@ -72,7 +72,7 @@ public:
       const sstable::BlockReaderCache *block_reader_cache) const;
 
   std::unique_ptr<BlockReaderData>
-      SetupDataForBlockReader(BlockOffset offset) const;
+      SetupDataForBlockReader(uint64_t block_size, BlockOffset offset) const;
 
   const std::shared_ptr<io::ReadOnlyFile> GetReadFileObject() const;
 

--- a/sstable/table_reader.h
+++ b/sstable/table_reader.h
@@ -67,14 +67,12 @@ public:
 
   bool Open();
 
-  db::GetStatus SearchKey(
-      std::string_view key, TxnId txn_id,
-      const sstable::BlockReaderCache *block_reader_cache) const;
+  db::GetStatus
+  SearchKey(std::string_view key, TxnId txn_id,
+            const sstable::BlockReaderCache *block_reader_cache) const;
 
   std::unique_ptr<BlockReaderData>
-      SetupDataForBlockReader(uint64_t block_size, BlockOffset offset) const;
-
-  const std::shared_ptr<io::ReadOnlyFile> GetReadFileObject() const;
+  SetupDataForBlockReader(uint64_t block_size, BlockOffset offset) const;
 
   uint64_t GetFileSize() const;
 


### PR DESCRIPTION
Use const for all BlockReader's data members. Because BlockReader is a read-only object(after be constructed), using non-const can be dangerous if any of data members is changed